### PR TITLE
fixup: sync package.yaml and mockery.cabal

### DIFF
--- a/mockery.cabal
+++ b/mockery.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.5.4.
+-- This file has been generated from package.yaml by hpack version 0.11.0.
 --
 -- see: https://github.com/sol/hpack
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 license:        MIT
-version:        0.3.1
+version:        0.3.2
 copyright:      (c) 2015 Simon Hengel
 author:         Simon Hengel <sol@typeful.net>
 maintainer:     Simon Hengel <sol@typeful.net>


### PR DESCRIPTION
Fixes the inconsistency between the hpack and the cabal file, as pointed out by @tmbull here: #7.
