### PR TITLE
Fix the build on GHC 7.4 and earlier

### DIFF
--- a/src/Test/Mockery/Logging.hs
+++ b/src/Test/Mockery/Logging.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 module Test.Mockery.Logging (
   captureLogMessages
@@ -6,11 +5,10 @@ module Test.Mockery.Logging (
 , LogLevel(..)
 ) where
 
-#if !MIN_VERSION_base(4,8,0)
-import           Control.Applicative
-#endif
 import           Control.Exception
-import           Data.IORef
+import           Data.IORef.Compat
+import           Prelude ()
+import           Prelude.Compat
 import           System.Logging.Facade.Types
 import           System.Logging.Facade.Sink
 


### PR DESCRIPTION
Building `mockery` on GHC 7.4 errored with:

```
[1 of 3] Compiling Test.Mockery.Logging ( src/Test/Mockery/Logging.hs, dist/build/Test/Mockery/Logging.o )

src/Test/Mockery/Logging.hs:22:27:
    Not in scope: atomicModifyIORef'
    Perhaps you meant `atomicModifyIORef' (imported from Data.IORef)
```

Luckily, `mockery` is already using `base-compat`, so fixing this is simple.